### PR TITLE
fix: app.json not kept due to having comments

### DIFF
--- a/app.json
+++ b/app.json
@@ -80,11 +80,9 @@
     ],
     "extra": {
       "eas": {
-        // Replace with your own project ID
         "projectId": "1c1a9df8-1e2d-45ef-8667-90a2b9e0d5d3"
       }
     },
-    // Replace with your own owner
     "owner": "divvi"
   }
 }


### PR DESCRIPTION
### Description

When following our docs, running `yarn create expo my-app --template https://github.com/divvi-xyz/divvi-app-starter my-app` did not keep the content of the template `app.json`, because it had comments in it.

This is an alternative to #17

### Testing

- Checked `yarn create expo --template file:./divvi-app-starter my-app` now works as expected and the app compiles and runs.

### Related Issues

Fixes #11
